### PR TITLE
Fix for negative value from DB

### DIFF
--- a/includes/class/class-apl-post-list.php
+++ b/includes/class/class-apl-post-list.php
@@ -357,7 +357,9 @@ class APL_Post_List {
 			$this->post_parent__in     = get_post_meta( $this->id, 'apl_post_parent__in', true )     ?: array();
 			$this->post_parent_dynamic = get_post_meta( $this->id, 'apl_post_parent_dynamic', true ) ?: array();
 			$this->posts_per_page      = get_post_meta( $this->id, 'apl_posts_per_page', true )      ?: 5;
+			$this->posts_per_page      = intval( $this->posts_per_page );
 			$this->offset              = get_post_meta( $this->id, 'apl_offset', true )              ?: 0;
+			$this->offset              = intval( $this->offset );
 			$this->order_by            = get_post_meta( $this->id, 'apl_order_by', true )            ?: 'none';
 			$this->order               = get_post_meta( $this->id, 'apl_order', true )               ?: 'DESC';
 			$this->author__bool        = get_post_meta( $this->id, 'apl_author__bool', true )        ?: 'none';


### PR DESCRIPTION
@EkoJR When retrieving from DB the posts_per_page "-1" value is a string, so on further strict conditions evaluating the posts_per_page value to assign or not to assign the nopaging flag, the condition evaluates to false and finally WP_Query constructs and invalid SQL query with a LIMIT 0, -1, which launches a MySQL error, and nothing gets listed.